### PR TITLE
Improve test reliability by cleaning the state after running test_user_input_password_not_found

### DIFF
--- a/tests/test_user_input.py
+++ b/tests/test_user_input.py
@@ -1,3 +1,4 @@
+import sys
 import vcr
 
 from unittest.mock import patch
@@ -28,3 +29,4 @@ def test_user_input_password_not_found(getpass, capsys):
     captured_lines = captured.out.splitlines()
     assert len(captured_lines) == 1
     assert captured_lines[0] == "Could not find that password in the dataset."
+    del sys.modules['keepassxc_pwned.__main__']


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_user_input_password_not_found` by cleaning the state after running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_user_input.py::test_user_input_password_not_found`.
```
        import keepassxc_pwned.__main__

        captured = capsys.readouterr()
        captured_lines = captured.out.splitlines()
>       assert len(captured_lines) == 1
E       assert 0 == 1
E        +  where 0 = len([])
```
More specifically, this PR cleans the state by removing the imported module (in `import keepassxc_pwned.__main__`). In this way, the test does not fail on the second run any more.

It may be better to avoid state pollutions so that some other tests won't fail in the future due to the shared state pollution.
